### PR TITLE
Link Job Scheduler to Scheduling Metaflow Flows

### DIFF
--- a/introduction/what-is-metaflow.md
+++ b/introduction/what-is-metaflow.md
@@ -68,7 +68,7 @@ You can find more details about Metaflow's approach to various parts of the stac
     <tr>
       <td style="text-align:left"><b>Job Scheduler </b>
       </td>
-      <td style="text-align:left">coming soon, see <a href="roadmap.md">Roadmap</a>
+      <td style="text-align:left"><a href="../going-to-production-with-metaflow/scheduling-metaflow-flows.md">Scheduling Metaflow Flows</a>
       </td>
     </tr>
     <tr>


### PR DESCRIPTION
Step Function support was just released: https://netflixtechblog.com/unbundling-data-science-workflows-with-metaflow-and-aws-step-functions-d454780c6280

Looks like this reference was missed.