### PR TITLE
Patch nonfunctional example in "Basics of Metaflow"

### DIFF
--- a/metaflow/basics.md
+++ b/metaflow/basics.md
@@ -297,7 +297,7 @@ class MergeArtifactsFlow(FlowSpec):
 
     @step
     def c(self):
-        self.next(self.d, step.e)
+        self.next(self.d, self.e)
 
     @step
     def d(self):


### PR DESCRIPTION
The [example](https://docs.metaflow.org/metaflow/basics#data-flow-through-the-graph) which illustrates how data is passed down a pipeline doesn't work, producing
```
Step join is both a join step (it takes an extra argument) and a split step (it transitions to multiple steps). This is not allowed. Add a new step so that split and join become separate steps.
```

I modified it by separating the step `join` into two steps, `join` and `c`. Incremented the steps `c` and `d` to be called steps `d` and `e` to maintain the existing naming convention.


See issue #3 .