### PR TITLE
Fixed bug where single children were ignored

### DIFF
--- a/src/components/DocSection/DocSection.js
+++ b/src/components/DocSection/DocSection.js
@@ -41,16 +41,14 @@ export const DocSection = ({
         from {module} import {name}
       </p>
       <div className={styles.content}>
-        {children.length
-          ? children.filter((child) => child.props.mdxType === "Description")
-          : null}
-        {children.length
-          ? children.filter(
-              (child) =>
-                child.props.mdxType !== "Description" &&
-                child.props.mdxType !== "SigArgSection"
-            )
-          : null}
+        {React.Children.toArray(children).filter(
+          (child) => child.props.mdxType === "Description"
+        )}
+        {React.Children.toArray(children).filter(
+          (child) =>
+            child.props.mdxType !== "Description" &&
+            child.props.mdxType !== "SigArgSection"
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
When is only one child to DocSection, react gives it as an object, rather than a single item array. Changed the code to convert all cases to an array before filtering sections.