### PR TITLE
Fix getting started tutorial local path

### DIFF
--- a/docs/getting-started/tutorials/season-1-the-local-experience/episode00.md
+++ b/docs/getting-started/tutorials/season-1-the-local-experience/episode00.md
@@ -13,7 +13,7 @@ You can find the tutorial code on [GitHub](https://github.com/Netflix/metaflow/t
 
 #### To play this episode:
 
-1. `cd metaflow-tutorials`
+1. `cd metaflow/tutorials`
 2. `python 00-helloworld/helloworld.py show`
 3. `python 00-helloworld/helloworld.py run`
 


### PR DESCRIPTION
The suggested command to `cd` into the tutorial directory is no longer correct.