### PR TITLE
Add numpydoc docstring standard to contribution guide

### DIFF
--- a/docs/internals/contributing.md
+++ b/docs/internals/contributing.md
@@ -20,6 +20,12 @@ We will do our best to respond to and review your PR and we hope you will stay e
 
 We'd appreciate [issue reports](https://github.com/Netflix/metaflow/issues) if you run into trouble using Metaflow.
 
+#### Code Style
+
+We use [black](https://black.readthedocs.io/en/stable/) as a code formatter. The easiest way to ensure your commits are always formatted with the correct version of `black` it is to use [pre-commit](https://pre-commit.com/): install it and then run `pre-commit install` once in your local copy of the repo.
+
+We also follow the [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) docstring style to enable automatic documentation using [Sphinx](https://www.sphinx-doc.org/en/master/).
+
 ### Community
 
 Everyone is welcome to join us in our [chatroom](http://chat.metaflow.org/)!


### PR DESCRIPTION
Relates to old, closed issue #383.