### PR TITLE
Fixed README.md links

### DIFF
--- a/docs/production/event-triggering/README.md
+++ b/docs/production/event-triggering/README.md
@@ -33,15 +33,15 @@ section is relevant for more advanced use cases that leverage [the `@project`
 decorator](/production/coordinating-larger-metaflow-projects) to deploy
 multiple concurrent variants of event-triggered flows. 
 
- 1. [Triggering flows based on external events](/docs/production/event-triggering/external-events)
- 2. [Triggering flows based on other flows](/docs/production/event-triggering/flow-events)
- 3. [Inspecting events](/docs/production/event-triggering/inspect-events)
- 4. [Deploying variants of event-triggered flows](/docs/production/event-triggering/project-events)
+ 1. [Triggering flows based on external events](/docs/production/event-triggering/external-events.md)
+ 2. [Triggering flows based on other flows](/docs/production/event-triggering/flow-events.md)
+ 3. [Inspecting events](/docs/production/event-triggering/inspect-events.md)
+ 4. [Deploying variants of event-triggered flows](/docs/production/event-triggering/project-events.md)
 
 :::info
 
 As of today, event triggering is only supported on
-[Argo Workflows](/docs/production/scheduling-metaflow-flows/scheduling-with-argo-workflows).
+[Argo Workflows](/docs/production/scheduling-metaflow-flows/scheduling-with-argo-workflows.md).
 Let us know on [Metaflow community Slack](http://slack.outerbounds.co) if you would
 like to see other production orchestrators supported as well.
 

--- a/docs/production/event-triggering/README.md
+++ b/docs/production/event-triggering/README.md
@@ -33,15 +33,15 @@ section is relevant for more advanced use cases that leverage [the `@project`
 decorator](/production/coordinating-larger-metaflow-projects) to deploy
 multiple concurrent variants of event-triggered flows. 
 
- 1. [Triggering flows based on external events](/production/event-triggering/external-events)
- 2. [Triggering flows based on other flows](/production/event-triggering/flow-events)
- 3. [Inspecting events](/production/event-triggering/inspect-events)
- 4. [Deploying variants of event-triggered flows](/production/event-triggering/project-events)
+ 1. [Triggering flows based on external events](/docs/production/event-triggering/external-events)
+ 2. [Triggering flows based on other flows](/docs/production/event-triggering/flow-events)
+ 3. [Inspecting events](/docs/production/event-triggering/inspect-events)
+ 4. [Deploying variants of event-triggered flows](/docs/production/event-triggering/project-events)
 
 :::info
 
 As of today, event triggering is only supported on
-[Argo Workflows](/production/scheduling-metaflow-flows/scheduling-with-argo-workflows).
+[Argo Workflows](/docs/production/scheduling-metaflow-flows/scheduling-with-argo-workflows).
 Let us know on [Metaflow community Slack](http://slack.outerbounds.co) if you would
 like to see other production orchestrators supported as well.
 


### PR DESCRIPTION
The links to the docs are broken in Readme.md for event-triggering, just fixed them.