### PR TITLE
docs: fix typo in Technical Overview's Metadata Provider section

### DIFF
--- a/docs/internals/technical-overview.md
+++ b/docs/internals/technical-overview.md
@@ -220,11 +220,11 @@ functionality is not required by Metaflow, but it makes the system much more **u
 The service also helps to make data artifacts and other metadata about runs more
 discoverable during result-time, as explained below.
 
-- \`\`[`metadata.py` - base class for metadata
+- [`metadata.py` - base class for metadata
   providers](https://github.com/Netflix/metaflow/blob/master/metaflow/metadata/metadata.py)
-- \`\`[`service.py` - default implementation of the metadata
+- [`service.py` - default implementation of the metadata
   provider](https://github.com/Netflix/metaflow/blob/master/metaflow/plugins/metadata/service.py)
-- \`\`[`local.py` - local implementation of the metadata
+- [`local.py` - local implementation of the metadata
   provider](https://github.com/Netflix/metaflow/blob/master/metaflow/plugins/metadata/local.py)
 
 ## Result-time Components


### PR DESCRIPTION
## Summary

Remove extra, rendered backticks

Noticed this a good number of months ago and seemed like it never got fixed, so figured I'd fix it myself then 🙂 

## Details

- there were extra backticks that were also escaped
  - not sure why, but the rest of this doc does not have those
  - and these got rendered out due to the escaping as well
  
### Screenshot Diff

_Previously_ looked like (before):

![Screenshot 2023-11-12 at 3 10 44 PM](https://github.com/Netflix/metaflow-docs/assets/4970083/d510d7f1-a5de-4cea-a626-955e3cc02b4e)

_Now_ looks like (after):

![Screenshot 2023-11-12 at 3 17 10 PM](https://github.com/Netflix/metaflow-docs/assets/4970083/7bc33eb4-4bac-49c5-8c59-8849a6b50618)


## Validation

`yarn lint` runs fine on this part of the docs (it currently has warnings on an unrelated part of the docs)