### PR TITLE
feat(docs): Add scroll-to-top button for documentation pages

### DIFF
--- a/src/components/ScrollToTopButton/index.js
+++ b/src/components/ScrollToTopButton/index.js
@@ -1,0 +1,29 @@
+import React, { useState, useEffect } from "react";
+import styles from "./styles.module.css";
+
+export default function ScrollToTopButton() {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    const onScroll = () => setVisible(window.scrollY > 300);
+    window.addEventListener("scroll", onScroll, { passive: true });
+    return () => window.removeEventListener("scroll", onScroll);
+  }, []);
+
+  const scrollToTop = () => {
+    window.scrollTo({ top: 0, behavior: "smooth" });
+  };
+
+  if (!visible) return null;
+
+  return (
+    <button
+      className={styles.scrollToTop}
+      onClick={scrollToTop}
+      aria-label="Scroll to top"
+      title="Scroll to top"
+    >
+      ↑
+    </button>
+  );
+}

--- a/src/components/ScrollToTopButton/styles.module.css
+++ b/src/components/ScrollToTopButton/styles.module.css
@@ -1,0 +1,26 @@
+.scrollToTop {
+  position: fixed;
+  bottom: 2rem;
+  right: 2rem;
+  z-index: 999;
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 50%;
+  border: none;
+  background-color: var(--ifm-color-primary);
+  color: #fff;
+  font-size: 1.2rem;
+  line-height: 1;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.25);
+  transition: background-color 0.2s, opacity 0.2s, transform 0.2s;
+  opacity: 0.85;
+}
+
+.scrollToTop:hover {
+  opacity: 1;
+  transform: translateY(-2px);
+}

--- a/src/theme/Root.js
+++ b/src/theme/Root.js
@@ -1,0 +1,11 @@
+import React from "react";
+import ScrollToTopButton from "@site/src/components/ScrollToTopButton";
+
+export default function Root({ children }) {
+  return (
+    <>
+      {children}
+      <ScrollToTopButton />
+    </>
+  );
+}


### PR DESCRIPTION
## Summary

- Added a fixed scroll-to-top button that appears on all documentation pages
- Button shows after scrolling 300px and smoothly returns user to the top
- Adapts to light/dark mode via `--ifm-color-primary` CSS variable


## Fixed 
- Fixed #179 
## Changes

- `src/components/ScrollToTopButton/index.js` — React component with scroll
  listener and conditional render
- `src/components/ScrollToTopButton/styles.module.css` — scoped styles,
  fixed bottom-right, hover lift effect
- `src/theme/Root.js` — Docusaurus `Root` swizzle to inject the button
  globally across all pages


## Before 

[Screencast From 2026-02-27 07-28-04.webm](https://github.com/user-attachments/assets/709c5e79-10b7-41e3-96b8-2d5e3c430890)

## After 

[Screencast From 2026-02-27 07-29-37.webm](https://github.com/user-attachments/assets/7d1a11a7-2b49-4f96-abd8-706304e3654c)
