### PR TITLE
fix: correct Algolia indexName typo from "metataflow" to "metaflow"

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -97,7 +97,7 @@ const config = {
         // Public API key: it is safe to commit it
         apiKey: "246d8e1f6a4c455ba30172edcd0399d5",
 
-        indexName: "metataflow",
+        indexName: "metaflow",
 
         // Optional: see doc section below
         contextualSearch: true,


### PR DESCRIPTION
## Problem
The Algolia search `indexName` was set to `"metataflow"` (extra `ta`),
which does not match the registered Algolia index. This caused every
search query on the docs site to return zero results — making the
search bar completely non-functional for all users.

## Change
- `docusaurus.config.js` line 100: `"metataflow"` → `"metaflow"`

## Result
Docusaurus search now connects to the correct Algolia index and
returns relevant documentation pages as expected.

## Fixed #183 