### PR TITLE
fix: change editUrl from github.dev to github.com for correct "Edit this page" link

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -37,7 +37,7 @@ const config = {
           // remarkPlugins: [[remarkCodeHike, { theme }]],
           sidebarPath: require.resolve("./sidebars.js"),
           // Please change this to your repo.
-          editUrl: "https://github.dev/Netflix/metaflow-docs/blob/master",
+          editUrl: "https://github.com/Netflix/metaflow-docs/blob/master",
           routeBasePath: "/",
         },
         theme: {


### PR DESCRIPTION
## Problem
The `editUrl` in `docusaurus.config.js` was set to `https://github.dev/...`
which opens GitHub's in-browser VS Code editor when a user clicks
"Edit this page" at the bottom of any doc page.

This is confusing for contributors — `github.dev` has no clear path
to fork the repo and raise a PR. The standard GitHub file view at
`github.com` is what contributors expect.

## Change
- `docusaurus.config.js` line 40: `github.dev` → `github.com`

## Result
Clicking "Edit this page" now opens the standard GitHub file view,
where contributors can easily fork → edit → open a PR.

## Fixed #184 